### PR TITLE
fix(mutator): ignore comments when generating mutants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,10 @@ All notable changes to this project will be documented in this file.
 This project aims to follow Semantic Versioning. While <1.0, minor releases should remain backwards compatible when reasonable.
 
 ## [Unreleased]
-Planned for: `0.2.0-alpha.1`
-
-### Added
-- _TBD_
-
-### Changed
-- _TBD_
+Planned for: `0.1.1`
 
 ### Fixed
-- _TBD_
+- Fix: do not generate mutants from line/block comments (e.g., // ===== and equations in comments).
 
 ## [0.1.0] - 2025-12-23
 

--- a/src/snapshots/zk_mutant__discover__tests__discover_simple_noir.snap
+++ b/src/snapshots/zk_mutant__discover__tests__discover_simple_noir.snap
@@ -27,8 +27,8 @@ expression: mutants
         },
         span: SourceSpan {
             file: "src/main.nr",
-            start: 94,
-            end: 96,
+            start: 467,
+            end: 469,
         },
         original_snippet: "!=",
         mutated_snippet: "==",

--- a/tests/fixtures/simple_noir/src/main.nr
+++ b/tests/fixtures/simple_noir/src/main.nr
@@ -2,7 +2,19 @@ mod utils;
 
 fn main(x: u64, y: pub u64) {
     assert(x < y);
-    // test comment
+
+    // ===========================================================================
+    // If pubkey IS in tree: leaf != 0, proof generation fails
+    // If pubkey NOT in tree: leaf == 0, proof succeeds
+    // Also: a <= b && c >= d || e == f
+    // ===========================================================================
+
+    /*
+    Block comment too:
+    leaf != 0
+    leaf == 0
+    */
+
     assert(x != y);
     utils::check_addition(1, 2);
 }

--- a/tests/snapshots/cli_integration__list_fixture.snap
+++ b/tests/snapshots/cli_integration__list_fixture.snap
@@ -12,7 +12,7 @@ discovered 4 mutants
 listed 4 mutants
 --- mutants (discovered) ---
 #1 src/main.nr:4:14-4:15 Condition/lt_to_ge: "<" -> ">="
-#2 src/main.nr:6:14-6:16 Condition/neq_to_eq: "!=" -> "=="
+#2 src/main.nr:18:14-18:16 Condition/neq_to_eq: "!=" -> "=="
 #3 src/utils.nr:4:18-4:20 Condition/eq_to_neq: "==" -> "!="
 #4 src/utils.nr:10:14-10:16 Condition/eq_to_neq: "==" -> "!="
 --- stderr ---

--- a/tests/snapshots/cli_integration__list_fixture_json.snap
+++ b/tests/snapshots/cli_integration__list_fixture_json.snap
@@ -33,8 +33,8 @@ expression: out
       },
       "span": {
         "file": "src/main.nr",
-        "start": 94,
-        "end": 96
+        "start": 467,
+        "end": 469
       },
       "original_snippet": "!=",
       "mutated_snippet": "==",

--- a/tests/snapshots/cli_integration__run_no_limit_json.snap
+++ b/tests/snapshots/cli_integration__run_no_limit_json.snap
@@ -43,8 +43,8 @@ expression: out
       },
       "span": {
         "file": "src/main.nr",
-        "start": 94,
-        "end": 96
+        "start": 467,
+        "end": 469
       },
       "original_snippet": "!=",
       "mutated_snippet": "==",


### PR DESCRIPTION
Fixes #1

## Summary
This PR fixes a breaking discovery bug that caused `zk-mutant` to generate mutants from comment text. In practice, comment separators and “equations in comments” (e.g., `// ======`, `!=`, `==`, `<=`, `>=`) were treated as mutation candidates, causing a large and noisy mutant explosion.

## What changed
- Mutation discovery now **ignores line comments** (`// ...`) and **block comments** (`/* ... */`) when collecting operator matches.
- Added/updated fixture content to include “operator-like” comment text to prevent regressions.
- Updated snapshots accordingly.

## Reproduction (before)
Given a Noir file containing comments like:
```text
// ===========================================================================
// If pubkey IS in tree: leaf != 0, proof generation fails
// If pubkey NOT in tree: leaf == 0, proof succeeds
```

`zk-mutant scan` / `zk-mutant list` would discover many additional mutants originating from those comments.

## Expected behavior (after)
No mutants are generated from comment text. Only operators in real code are considered mutation candidates.

## Validation
- `cargo test`
- `cargo insta test`
- Manual run on fixture project:
  - `zk-mutant run --project ./tests/fixtures/simple_noir/` → discovers 4 mutants (no comment-derived mutants)
